### PR TITLE
Add _M_IX86 for testing for MSVC x86

### DIFF
--- a/bn_mp_set_double.c
+++ b/bn_mp_set_double.c
@@ -3,7 +3,7 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(__aarch64__) || defined(__arm__)
+#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(_M_IX86) || defined(__aarch64__) || defined(__arm__)
 mp_err mp_set_double(mp_int *a, double b)
 {
    uint64_t frac;


### PR DESCRIPTION
This PR pulls in a libtommath commit that fixes building of libtommath / MoarVM on Windows with recent MSVC compilers on 32bit x86. The MSVC compiler had a change in the preprocessor defines that broke CPU detection. This commit fixes that.

The branch this PR targets is named _very specifically_. So I would prefer _not_ to just merge this PR into that branch, but instead create a new branch (maybe just named "v1.2.0_plus_moar_changes"). I have no permission to do so, but someone else will.